### PR TITLE
Loading external configs from S3

### DIFF
--- a/load-test/build.gradle
+++ b/load-test/build.gradle
@@ -30,10 +30,11 @@ gatling {
 }
 
 task('uploadReport', type: JavaExec) {
-    main = 'com.vivareal.search.config.S3Uploader'
+    main = 'com.vivareal.search.config.SimulationResultsProcessor'
     args = ['build/reports/gatling', System.getenv('REPORT_VERSION') ?: 'SNAPSHOT']
     jvmArgs = System.properties.findAll { prop -> ['gatling', 'api', 'aws', 'slack'].findAll { allowedKey -> prop.key.startsWith("$allowedKey.") } }.collect { "-D$it" }
     classpath sourceSets.gatling.runtimeClasspath
     classpath configurations.gatling
 }
+
 uploadReport.mustRunAfter gatlingRun

--- a/load-test/src/gatling/scala/com/vivareal/search/config/ScenariosLoader.scala
+++ b/load-test/src/gatling/scala/com/vivareal/search/config/ScenariosLoader.scala
@@ -1,0 +1,30 @@
+package com.vivareal.search.config
+
+import java.lang.System.getProperty
+
+import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.ConfigFactory.{parseString}
+import com.vivareal.search.config.S3Client.readFromBucket
+
+object ScenariosLoader {
+
+  private val DEFAULT_SCENARIOS_FILE: String = "scenarios.conf"
+
+  def load():Config = {
+    Option(getProperty("scenarios.s3.path")).map(path => fromS3(path)).getOrElse(defaultScenarios())
+  }
+
+  private def defaultScenarios():Config = {
+    ConfigFactory.load(DEFAULT_SCENARIOS_FILE)
+  }
+
+  private def fromS3(fullS3Path: String):Config = {
+    println("Loading config from: " + fullS3Path)
+    val s3Path = fullS3Path.replaceAll("s3://", "")
+
+    val bucket = s3Path.substring(0, s3Path.indexOf("/"))
+    val key = s3Path.substring(bucket.length + 1, s3Path.length)
+
+    parseString(readFromBucket(bucket, key))
+  }
+}

--- a/load-test/src/gatling/scala/com/vivareal/search/config/SimulationResultsProcessor.scala
+++ b/load-test/src/gatling/scala/com/vivareal/search/config/SimulationResultsProcessor.scala
@@ -1,0 +1,19 @@
+package com.vivareal.search.config
+
+import java.io.File
+
+import com.vivareal.search.config.S3Client.uploadReport
+import com.vivareal.search.config.SlackNotifier.sendReportLink
+
+import scala.util.Try
+
+object SimulationResultsProcessor {
+
+  def main(args: Array[String]): Unit = {
+    val source = new File(args(0)).listFiles.sortWith((f1, f2) => f1.lastModified > f2.lastModified).head
+    val prefix = Try(args(1)).map(p => s"$p/").getOrElse("")
+
+    uploadReport(source, prefix)
+    sendReportLink(source, prefix)
+  }
+}

--- a/load-test/src/gatling/scala/com/vivareal/search/context/SourceFeederByFile.scala
+++ b/load-test/src/gatling/scala/com/vivareal/search/context/SourceFeederByFile.scala
@@ -1,0 +1,19 @@
+package com.vivareal.search.context
+
+import java.io.File
+
+import com.typesafe.config.Config
+import com.vivareal.search.util.PaginationUtils.applyPagination
+
+import scala.io.Source.fromFile
+
+object SourceFeederByFile extends SourceFeeder {
+
+  def feeds(config: Config): Array[Map[String, String]] = {
+    fromFile(new File(getClass.getClassLoader.getResource(config.getString("scenario.file")).getPath))
+      .getLines
+      .map(line => Map("line" -> line))
+      .map(feed => applyPagination(feed))
+      .toArray
+  }
+}

--- a/load-test/src/gatling/scala/com/vivareal/search/context/SourceFeederFromFile.scala
+++ b/load-test/src/gatling/scala/com/vivareal/search/context/SourceFeederFromFile.scala
@@ -1,0 +1,19 @@
+package com.vivareal.search.context
+
+import java.io.File
+
+import com.typesafe.config.Config
+import com.vivareal.search.util.PaginationUtils.applyPagination
+
+import scala.io.Source.fromFile
+
+object SourceFeederFromFile extends SourceFeeder {
+
+  def feeds(config: Config): Array[Map[String, String]] = {
+    fromFile(new File(getClass.getClassLoader.getResource(config.getString("scenario.file")).getPath))
+      .getLines
+      .map(line => Map("line" -> line))
+      .map(feed => applyPagination(feed))
+      .toArray
+  }
+}

--- a/load-test/src/gatling/scala/com/vivareal/search/context/SourceFeederFromS3.scala
+++ b/load-test/src/gatling/scala/com/vivareal/search/context/SourceFeederFromS3.scala
@@ -1,19 +1,15 @@
 package com.vivareal.search.context
 
-import java.io.File
-
 import com.typesafe.config.Config
+import com.vivareal.search.config.S3Client.readFromBucket
 import com.vivareal.search.util.PaginationUtils.applyPagination
 
-import scala.io.Source.fromFile
-
-object SourceFeederByFile extends SourceFeeder {
+object SourceFeederFromS3 extends SourceFeeder {
 
   def feeds(config: Config): Array[Map[String, String]] = {
-    fromFile(new File(getClass.getClassLoader.getResource(config.getString("scenario.file")).getPath))
-      .getLines
+    readFromBucket(config.getString("scenario.bucket"), config.getString("scenario.key"))
+      .split("\n")
       .map(line => Map("line" -> line))
       .map(feed => applyPagination(feed))
-      .toArray
   }
 }

--- a/load-test/src/gatling/scala/com/vivareal/search/simulation/SearchAPIv2Simulation.scala
+++ b/load-test/src/gatling/scala/com/vivareal/search/simulation/SearchAPIv2Simulation.scala
@@ -2,9 +2,11 @@ package com.vivareal.search.simulation
 
 import com.typesafe.config.ConfigFactory.load
 import com.typesafe.config.ConfigValueFactory.fromAnyRef
+import com.vivareal.search.config.ScenariosLoader
 import com.vivareal.search.config.SearchAPIv2Feeder.feeder
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
+
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
@@ -25,7 +27,7 @@ class SearchAPIv2Simulation extends Simulation {
 
   private val index = globalConfig.getString("api.index")
 
-  private val scenariosConf = load("scenarios.conf")
+  private val scenariosConf = ScenariosLoader.load()
 
   private var scenarios = scenariosConf.getObjectList("scenarios").asScala
     .map(configValue => configValue.toConfig)


### PR DESCRIPTION
cc @VivaReal/squad-search 

- [x] Loading scenarios from S3
  e.g.  `-Dscenarios.s3.path=s3://search-us-east-1/load-tests/scenarios/scenarios.conf `
- [x] Adding feeder for scenarios from file
- [x] Adding feeder for scenarios from S3

Closes https://github.com/VivaReal/squad-search/issues/735