### PR TITLE
Removing code-style as submodule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,1 +1,0 @@
-code-style/.editorconfig

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "make"]
 	path = make
 	url = https://github.com/VivaReal/make-snippets
-[submodule "code-style"]
-	path = code-style
-	url = https://github.com/VivaReal/code-style


### PR DESCRIPTION
cc @VivaReal/squad-search 

Since with this PR https://github.com/VivaReal/search-api/pull/224 we adopted GJF 1.5 as project's code style; this submodule is no longer necessary